### PR TITLE
Display stack trace in case of exception

### DIFF
--- a/Shed/Program.fs
+++ b/Shed/Program.fs
@@ -106,6 +106,6 @@ module Program =
                 printUsage(parser.PrintUsage())   
                 1
             | e ->
-                printError(e.Message)
+                printError(e.ToString())
                 1
         


### PR DESCRIPTION
I was trying to use the tool to check w3wp process on my machine, unfortunately, I was getting 

> Object reference not set to an instance of an object.

exception without any stack trace.
This PR changes that, hope it helps.

![image](https://user-images.githubusercontent.com/2392583/33008687-583656ee-cdd4-11e7-87c6-0de63fd8b4e6.png)
